### PR TITLE
Cambios en el modo de vista claor y oscuro del tablero canvas

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -17,6 +17,7 @@
         "framer-motion": "^12.16.0",
         "lucide-react": "^0.514.0",
         "next": "15.3.1",
+        "next-themes": "^0.4.6",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-icons": "^5.5.0",
@@ -814,6 +815,8 @@
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
     "next": ["next@15.3.1", "", { "dependencies": { "@next/env": "15.3.1", "@swc/counter": "0.1.3", "@swc/helpers": "0.5.15", "busboy": "1.6.0", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.3.1", "@next/swc-darwin-x64": "15.3.1", "@next/swc-linux-arm64-gnu": "15.3.1", "@next/swc-linux-arm64-musl": "15.3.1", "@next/swc-linux-x64-gnu": "15.3.1", "@next/swc-linux-x64-musl": "15.3.1", "@next/swc-win32-arm64-msvc": "15.3.1", "@next/swc-win32-x64-msvc": "15.3.1", "sharp": "^0.34.1" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.41.2", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-8+dDV0xNLOgHlyBxP1GwHGVaNXsmp+2NhZEYrXr24GWLHtt27YrBPbPuHvzlhi7kZNYjeJNR93IF5zfFu5UL0g=="],
+
+    "next-themes": ["next-themes@0.4.6", "", { "peerDependencies": { "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc", "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc" } }, "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "framer-motion": "^12.16.0",
     "lucide-react": "^0.514.0",
     "next": "15.3.1",
+    "next-themes": "^0.4.6",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-icons": "^5.5.0",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -107,6 +107,9 @@
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(1 0 0 / 10%);
   --sidebar-ring: oklch(0.552 0.016 285.938);
+  /* Ajusta estos valores específicamente */
+  --canvas: 240 10% 8%;     /* Gris más oscuro para el canvas */
+  --sidebar: 240 10% 14%;   /* Gris más claro para el sidebar */
 }
 
 @layer base {
@@ -121,3 +124,73 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+ 
+@layer base {
+  :root {
+    --background: 0 0% 100%;
+    --foreground: 240 10% 3.9%;
+
+    --card: 0 0% 100%;
+    --card-foreground: 240 10% 3.9%;
+    
+    --sidebar: 0 0% 100%;
+    --canvas: 0 0% 98%;
+ 
+    --popover: 0 0% 100%;
+    --popover-foreground: 240 10% 3.9%;
+ 
+    --primary: 240 5.9% 10%;
+    --primary-foreground: 0 0% 98%;
+ 
+    --secondary: 240 4.8% 95.9%;
+    --secondary-foreground: 240 5.9% 10%;
+ 
+    --muted: 240 4.8% 95.9%;
+    --muted-foreground: 240 3.8% 46.1%;
+ 
+    --accent: 240 4.8% 95.9%;
+    --accent-foreground: 240 5.9% 10%;
+ 
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 0 0% 98%;
+ 
+    --border: 240 5.9% 90%;
+    --input: 240 5.9% 90%;
+    --ring: 240 10% 3.9%;
+ 
+    --radius: 0.5rem;
+  }
+ 
+  .dark {
+    --background: 240 10% 5%;
+    --foreground: 0 0% 98%;
+ 
+    --card: 240 10% 8%;
+    --card-foreground: 0 0% 98%;
+    
+    --sidebar: 240 10% 10%;
+    --canvas: 240 10% 7%;
+ 
+    --popover: 240 10% 8%;
+    --popover-foreground: 0 0% 98%;
+ 
+    --primary: 0 0% 98%;
+    --primary-foreground: 240 5.9% 10%;
+ 
+    --secondary: 240 3.7% 15.9%;
+    --secondary-foreground: 0 0% 98%;
+ 
+    --muted: 240 3.7% 15.9%;
+    --muted-foreground: 240 5% 64.9%;
+ 
+    --accent: 240 3.7% 15.9%;
+    --accent-foreground: 0 0% 98%;
+ 
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 0 0% 98%;
+ 
+    --border: 240 3.7% 15.9%;
+    --input: 240 3.7% 15.9%;
+    --ring: 240 4.9% 83.9%;
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,17 +1,14 @@
 import ClientProviders from "@/components/ClientProviders";
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Poppins } from "next/font/google";
 import "./globals.css";
 import { WhatsAppProvider } from '@/context/WhatsAppContext';
+import { ThemeProvider } from "next-themes"
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const poppins = Poppins({
   subsets: ["latin"],
-}); 
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
+  weight: ['400', '500', '600', '700'],
+  display: 'swap',
 });
 
 export const metadata: Metadata = {
@@ -25,13 +22,20 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className="scroll-smooth">
+    <html lang="es" className="scroll-smooth" suppressHydrationWarning>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${poppins.className} antialiased`}
       >
         <ClientProviders>
           <WhatsAppProvider>
-            {children}
+            <ThemeProvider
+              attribute="class"
+              defaultTheme="system"
+              enableSystem
+              disableTransitionOnChange
+            >
+              {children}
+            </ThemeProvider>
           </WhatsAppProvider>
         </ClientProviders>
       </body>

--- a/src/components/flows/ThemeSwitcher.tsx
+++ b/src/components/flows/ThemeSwitcher.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import { Moon, Sun, Monitor } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { useTheme } from "next-themes"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+
+export function ThemeSwitcher() {
+  const { setTheme } = useTheme()
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="outline"
+          size="icon"
+          className="bg-background text-black hover:bg-accent/50 hover:text-white 
+          data-[state=open]:bg-accent/50 data-[state=open]:text-white
+          dark:bg-background dark:text-white"
+        >
+          <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all 
+          dark:-rotate-90 dark:scale-0" />
+          <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all 
+          dark:rotate-0 dark:scale-100" />
+          <span className="sr-only">Cambiar tema</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="dark:bg-[hsl(240,3.7%,15.9%)]">
+        <DropdownMenuItem
+          onClick={() => setTheme("light")}
+          className="group flex items-center cursor-pointer hover:bg-accent/50"
+        >
+          <Sun className="h-4 w-4 mr-2 text-black dark:text-white group-hover:text-white" />
+          <span className="text-black dark:text-white group-hover:text-white">Claro</span>
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          onClick={() => setTheme("dark")}
+          className="group flex items-center cursor-pointer hover:bg-accent/50"
+        >
+          <Moon className="h-4 w-4 mr-2 text-black dark:text-white group-hover:text-white" />
+          <span className="text-black dark:text-white group-hover:text-white">Oscuro</span>
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          onClick={() => setTheme("system")}
+          className="group flex items-center cursor-pointer hover:bg-accent/50"
+        >
+          <Monitor className="h-4 w-4 mr-2 text-black dark:text-white group-hover:text-white" />
+          <span className="text-black dark:text-white group-hover:text-white">Sistema</span>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/src/components/flows/estilos.tsx
+++ b/src/components/flows/estilos.tsx
@@ -1,0 +1,39 @@
+import { Moon, Sun, Monitor } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { useTheme } from "next-themes"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+
+export function ThemeSwitcher() {
+  const { setTheme } = useTheme()
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" size="icon">
+          <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+          <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+          <span className="sr-only">Cambiar tema</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onClick={() => setTheme("light")}>
+          <Sun className="h-4 w-4 mr-2" />
+          Claro
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme("dark")}>
+          <Moon className="h-4 w-4 mr-2" />
+          Oscuro
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme("system")}>
+          <Monitor className="h-4 w-4 mr-2" />
+          Sistema
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/src/components/flows/flowcanvas.tsx
+++ b/src/components/flows/flowcanvas.tsx
@@ -3,6 +3,7 @@ import ReactFlow, { Background, Controls, MiniMap } from 'reactflow'
 import { useCallback, useRef, useState } from 'react'
 import { Button } from "@/components/ui/button"
 import { Trash2, Save } from "lucide-react"
+import { ThemeSwitcher } from '@/components/flows/ThemeSwitcher'
 
 // Use ReactFlow's NodeProps type instead of creating our own
 /*interface NodeData {
@@ -111,21 +112,22 @@ export function FlowCanvas({
   }, [nodes, edges]);
 
   return (
-    <div className="h-screen w-screen md:ml-[320px] bg-background relative">
+    <div className="h-screen w-screen md:ml-[320px] bg-[hsl(var(--canvas))] relative">
       {/* Panel fijo de botones */}
-      <div className="fixed right-4 top-4 z-[1000] flex gap-2 bg-background/80 p-2 rounded-lg backdrop-blur shadow-md">
+      <div className="fixed right-4 top-4 z-[1000] flex gap-2 bg-[hsl(var(--sidebar))] p-2 rounded-lg backdrop-blur shadow-md border">
+        <ThemeSwitcher />
         <Button 
           variant="destructive" 
           size="sm"
           onClick={() => setNodes([])}
         >
           <Trash2 className="h-4 w-4 mr-2" />
-          Clear Canvas
+          Limpiar Canvas
         </Button>
         <Button 
           onClick={handleSave}
           size="sm"
-          className="flex items-center gap-2 bg-primary text-white hover:bg-primary/90"
+          className="flex items-center gap-2 bg-primary text-white hover:bg-primary/90 dark:text-white dark:hover:bg-primary/70"
         >
           <Save className="h-4 w-4" />
           Guardar flujo
@@ -144,11 +146,11 @@ export function FlowCanvas({
           onDrop={onDrop}
           nodeTypes={nodeTypes}
           fitView
-          className="h-full w-full border rounded-lg"
+          className="h-full w-full border rounded-lg bg-[hsl(var(--canvas))]"
         >
-          <Controls className="!bg-background" />
+          <Controls className="!bg-[hsl(var(--sidebar))] border" />
           <Background />
-          <MiniMap className="!bg-background border rounded-lg" />
+          <MiniMap className="!bg-[hsl(var(--sidebar))] border rounded-lg" />
         </ReactFlow>
       </div>
     </div>

--- a/src/components/flows/sidebar.tsx
+++ b/src/components/flows/sidebar.tsx
@@ -30,7 +30,10 @@ export function Sidebar() {
               <Menu className="h-5 w-5" />
             </Button>
           </SheetTrigger>
-          <SheetContent side="left" className="w-[320px] p-4">
+          <SheetContent 
+            side="left" 
+            className="w-[320px] p-4 bg-[hsl(var(--sidebar))]"
+          >
             <div className="flex items-center gap-4 mb-4">
               <Link href="/services/flows/principal">
                 <Button 
@@ -42,7 +45,7 @@ export function Sidebar() {
                   <span className="sr-only">Volver a productos</span>
                 </Button>
               </Link>
-              <SheetTitle>herramientas de flujo</SheetTitle>
+              <SheetTitle>Herramientas de flujo</SheetTitle>
             </div>
             <SidebarContent />
           </SheetContent>
@@ -50,7 +53,7 @@ export function Sidebar() {
       </div>
 
       {/* Desktop Sidebar */}
-      <div className="hidden md:block fixed left-0 top-0 h-screen w-[320px] border-r bg-background p-4">
+      <div className="hidden md:block fixed left-0 top-0 h-screen w-[320px] border-r bg-[hsl(var(--sidebar))] p-4">
         <div className="flex items-center gap-4 mb-4">
           <Link href="/services/flows/principal">
             <Button 
@@ -62,7 +65,7 @@ export function Sidebar() {
               <span className="sr-only">Volver a productos</span>
             </Button>
           </Link>
-          <h2 className="text-lg font-semibold">herramientas de flujo</h2>
+          <h2 className="text-lg font-semibold">Herramientas de flujo</h2>
         </div>
         <SidebarContent />
       </div>
@@ -130,7 +133,10 @@ export function DraggableNode({ type, label, icon }: DraggableNodeProps) {
 
   return (
     <div
-      className="flex items-center gap-2 p-3 border rounded-lg cursor-move hover:border-primary transition-colors"
+      className="flex items-center gap-2 p-3 border rounded-lg cursor-move 
+      hover:border-primary transition-colors
+      bg-[hsl(var(--background))] dark:bg-[hsl(240,3.7%,30%)]
+      hover:bg-accent/50"
       draggable
       onDragStart={onDragStart}
     >


### PR DESCRIPTION
1. Implementación de Tema Oscuro
Se ajustó la escala de grises en el diseño
Se modificó el contraste entre el sidebar y el canvas
Se implementó la propiedad --sidebar y --canvas para control de colores
2. ThemeSwitcher
Se corrigió el color de los iconos en modo oscuro y claro
Se añadió dark:text-white para visibilidad en modo oscuro
Se mejoró la interactividad con estados hover y focus
3. Tipografía Poppins
Se implementó la fuente Poppins desde Google Fonts
Se configuraron los pesos de fuente necesarios
Se optimizó la carga con display: 'swap'
4. Mejoras de Accesibilidad
Se mantuvieron contrastes adecuados entre elementos
Se aseguró la legibilidad del texto en ambos modos
Se agregaron etiquetas sr-only para lectores de pantalla
5. Optimizaciones de UI/UX
Se mejoró la consistencia visual entre modos
Se añadieron transiciones suaves entre estados
Se implementaron efectos hover y focus consistentes